### PR TITLE
add[patch]: Change java.runtime.name to have android included (JRE 17-21)

### DIFF
--- a/patches/jre_17/android/27_change_runtime_name_android.diff
+++ b/patches/jre_17/android/27_change_runtime_name_android.diff
@@ -1,0 +1,18 @@
+// Changed java.runtime.name to include "Android" to support the detection scheme of sqlite-jdbc
+// See https://github.com/xerial/sqlite-jdbc/issues/1210
+// https://github.com/xerial/sqlite-jdbc/blob/79cc5feaf162679782e04e8691e55c7b6c90664f/src/main/java/org/sqlite/util/OSInfo.java#L120-L122
+
+diff --git a/make/conf/branding.conf b/make/conf/branding.conf
+index 0a8571e12..e27aebf2e 100644
+--- a/make/conf/branding.conf
++++ b/make/conf/branding.conf
+@@ -25,7 +25,7 @@
+ 
+ LAUNCHER_NAME=openjdk
+ PRODUCT_NAME=OpenJDK
+-PRODUCT_SUFFIX="Runtime Environment"
++PRODUCT_SUFFIX="Android Runtime Environment"
+ JDK_RC_PLATFORM_NAME=Platform
+ COMPANY_NAME=N/A
+ HOTSPOT_VM_DISTRO="OpenJDK"
+

--- a/patches/jre_21/android/27_change_runtime_name_android.diff
+++ b/patches/jre_21/android/27_change_runtime_name_android.diff
@@ -1,0 +1,18 @@
+// Changed java.runtime.name to include "Android" to support the detection scheme of sqlite-jdbc
+// See https://github.com/xerial/sqlite-jdbc/issues/1210
+// https://github.com/xerial/sqlite-jdbc/blob/79cc5feaf162679782e04e8691e55c7b6c90664f/src/main/java/org/sqlite/util/OSInfo.java#L120-L122
+
+diff --git a/make/conf/branding.conf b/make/conf/branding.conf
+index 912e4f622..27fd26607 100644
+--- a/make/conf/branding.conf
++++ b/make/conf/branding.conf
+@@ -25,7 +25,7 @@
+ 
+ LAUNCHER_NAME=openjdk
+ PRODUCT_NAME=OpenJDK
+-PRODUCT_SUFFIX="Runtime Environment"
++PRODUCT_SUFFIX="Android Runtime Environment"
+ JDK_RC_PLATFORM_NAME=Platform
+ COMPANY_NAME=N/A
+ HOTSPOT_VM_DISTRO="OpenJDK"
+


### PR DESCRIPTION
Changed java.runtime.name to include "Android" to support the detection scheme of sqlite-jdbc

See xerial/sqlite-jdbc#1210 and
https://github.com/xerial/sqlite-jdbc/blob/79cc5feaf162679782e04e8691e55c7b6c90664f/src/main/java/org/sqlite/util/OSInfo.java#L120-L122CC

This solves the issue we had with Distant Horizons for all versions and removes the need for hacky workarounds like including the native android lib for sqlite-jdbc in the JRE, replacing the linux lib with the android lib, or having a mod dlopen() or System.load() the android lib for sqlite-jdbc which is bound to break when DH decides to update their version of sqlite-jdbc

This is has been tested by me and @sa1672ndo on SM-A536E/DS and RMX2061 respectively