### PR TITLE
add[patch]: Change java.runtime.name to have android included (JRE8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ios-missing-include/Xm
 dizout
 jreout
 jdkout
+openjdk-*

--- a/patches/jdk8u_android.diff
+++ b/patches/jdk8u_android.diff
@@ -60908,3 +60908,16 @@ index 303c96d788..aa555cc286 100644
 +    }
 +
      /**
+diff --git a/common/autoconf/version-numbers b/common/autoconf/version-numbers
+index 73a0ffbd..ed42738d 100644
+--- a/common/autoconf/version-numbers
++++ b/common/autoconf/version-numbers
+@@ -29,7 +29,7 @@ JDK_MICRO_VERSION=0
+ JDK_UPDATE_VERSION=462
+ LAUNCHER_NAME=openjdk
+ PRODUCT_NAME=OpenJDK
+-PRODUCT_SUFFIX="Runtime Environment"
++PRODUCT_SUFFIX="Android Runtime Environment"
+ JDK_RC_PLATFORM_NAME=Platform
+ COMPANY_NAME=N/A
+


### PR DESCRIPTION
Part of #1. This one is more janky because the relevant refactoring serpent did to seperate out all the patches was not applied here.

Unsure if I should keep my changes to the end of the file or put it up to the top along with all the /common/* patches

DH behavior was tested on @sa1672ndo's RMX2061 running Turnip + Zink.