### PR TITLE
Fix jre file names in repackjre.sh

### DIFF
--- a/repackjre.sh
+++ b/repackjre.sh
@@ -27,7 +27,7 @@ compress_jars(){
 makearch () {
   echo "Making $2...";
   cd "$work";
-  tar xf $(find "$in" -name jre8-$2-*release.tar.xz) > /dev/null;
+  tar xf $(find "$in" -name jre8-android-$2-*release.tar.xz) > /dev/null;
   
   # Remove unused stuff before moving it
   rm bin/rmid

--- a/repackjre.sh
+++ b/repackjre.sh
@@ -58,6 +58,7 @@ makearch () {
 makeuni () { 
   echo "Making universal...";
   cd "$work";
+  echo $(find "$in" -name jre8-arm64-*release.tar.xz) > /dev/null; rm -rf bin;
   tar xf $(find "$in" -name jre8-arm64-*release.tar.xz) > /dev/null; rm -rf bin;
   rm -rf lib/aarch64;
   rm lib/jexec;

--- a/repackjre.sh
+++ b/repackjre.sh
@@ -58,8 +58,7 @@ makearch () {
 makeuni () { 
   echo "Making universal...";
   cd "$work";
-  echo $(find "$in" -name jre8-arm64-*release.tar.xz) > /dev/null; rm -rf bin;
-  tar xf $(find "$in" -name jre8-arm64-*release.tar.xz) > /dev/null; rm -rf bin;
+  tar xf $(find "$in" -name jre8-android-arm64-*release.tar.xz) > /dev/null; rm -rf bin;
   rm -rf lib/aarch64;
   rm lib/jexec;
   rm release;


### PR DESCRIPTION
The universal jre failed to build due the file name of the jre not being updated to include "android" in the `repackjre.sh` script after it was changed in [2c9325e](https://github.com/AngelAuraMC/angelauramc-openjdk-build/commit/2c9325e911cac7a64619734e435a4483ed3c1a9d).