### PR TITLE
ci_build_arch_*.sh: hand control over directly

### DIFF
--- a/ci_build_arch_aarch32.sh
+++ b/ci_build_arch_aarch32.sh
@@ -5,5 +5,4 @@ export TARGET=arm-linux-androideabi
 export TARGET_JDK=arm
 export NDK_PREBUILT_ARCH=/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/strip
 
-bash ci_build_global.sh
-
+exec bash ci_build_global.sh

--- a/ci_build_arch_aarch64.sh
+++ b/ci_build_arch_aarch64.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 if [[ "$BUILD_IOS" == "1" ]]; then
   export TARGET=aarch64-apple-darwin18.2
 else
@@ -8,5 +9,4 @@ fi
 export TARGET_JDK=aarch64
 export NDK_PREBUILT_ARCH=/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/aarch64-linux-android/bin/strip
 
-bash ci_build_global.sh
-
+exec bash ci_build_global.sh

--- a/ci_build_arch_x86.sh
+++ b/ci_build_arch_x86.sh
@@ -5,5 +5,4 @@ export TARGET=i686-linux-android
 export TARGET_JDK=x86
 export NDK_PREBUILT_ARCH=/toolchains/x86-4.9/prebuilt/linux-x86_64/i686-linux-android/bin/strip
 
-bash ci_build_global.sh
-
+exec bash ci_build_global.sh

--- a/ci_build_arch_x86_64.sh
+++ b/ci_build_arch_x86_64.sh
@@ -5,5 +5,4 @@ export TARGET=x86_64-linux-android
 export TARGET_JDK=x86_64
 export NDK_PREBUILT_ARCH=/toolchains/x86_64-4.9/prebuilt/linux-x86_64/x86_64-linux-android/bin/strip
 
-bash ci_build_global.sh
-
+exec bash ci_build_global.sh

--- a/ci_build_global.sh
+++ b/ci_build_global.sh
@@ -7,7 +7,7 @@ export JDK_DEBUG_LEVEL=release
 if [[ "$BUILD_IOS" != "1" ]]; then
   if [[ -d $NDK ]]; then
     echo "NDK already installed."
-  else 
+  else
     wget -nc -nv -O android-ndk-$NDK_VERSION-linux-x86_64.zip "https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip"
     ./extractndk.sh
   fi


### PR DESCRIPTION
exec to ci_build_global.sh from ci_build_arch_*.sh

by doing this we have -1 process doing nothing

kind of overoptimization, but anyway why not

also remove trailing space in ci_build_global.sh